### PR TITLE
Add macports-friendly library and include search paths to Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,7 +30,7 @@ LIB=$(PWD)/lib
 
 RM=rm -f
 CC=gcc
-CLD=gcc -O3 -L/usr/local/lib
+CLD=gcc -O3 -L/usr/local/lib -L/opt/local/lib
 YACC=bison -v -b$(GENERATED)/y
 LEX=lex
 
@@ -49,10 +49,11 @@ GENERATED=generated
 DEFINES=-DU2_OS_$(OS) -DU2_OS_ENDIAN_$(ENDIAN) -D U2_LIB=\"$(LIB)\"
 
 CFLAGS=-O3 \
-       	-I/usr/local/include \
+	-I/usr/local/include \
+	-I/opt/local/include \
 	-I$(INCLUDE)  \
 	-Ioutside/libuv/include \
- 	-I $(GENERATED) \
+	-I $(GENERATED) \
 	$(DEFINES)
 
 CWFLAGS=-Wall


### PR DESCRIPTION
This is a rather dumb way of doing it an assumes the compiler being
used will behave like gcc and search successive paths in order.

Short of cmake or autoconf I have been unable to find an idiomatic
solution to platform-specific paths.
