### PR TITLE
Set ctrl-h to be recognized as backspace.

### DIFF
--- a/v/term.c
+++ b/v/term.c
@@ -633,6 +633,9 @@ _term_io_suck_char(u2_utty* uty_u, c3_y cay_y)
     else if ( 0 == cay_y ) {
       _term_it_write_txt(uty_u, uty_u->ufo_u.out.bel_y);
     }
+    else if ( 8 == cay_y || 127 == cay_y ) {
+      _term_io_belt(uty_u, u2nc(c3__bac, u2_nul));
+    }
     else if ( 13 == cay_y ) {
       _term_io_belt(uty_u, u2nc(c3__ret, u2_nul));
     }
@@ -641,9 +644,6 @@ _term_io_suck_char(u2_utty* uty_u, c3_y cay_y)
     }
     else if ( 27 == cay_y ) {
       tat_u->esc.ape = u2_yes;
-    }
-    else if ( 127 == cay_y ) {
-      _term_io_belt(uty_u, u2nc(c3__bac, u2_nul));
     }
     else if ( cay_y >= 128 ) {
       tat_u->fut.len_w = 1;


### PR DESCRIPTION
On my terminal (default xterm on Slackware), ctrl-h (ASCII 8) is used for backspace.  This merely caused a beep in arvo, so I set it to be recognized as a backspace.  I did this on the c side because I'm not familiar enough with Hoon to change urb/zod/arvo/dill.hoon, but I think one could implement this after line 161 of that file (actions bound to control characters).  I don't really know if this will have any unintended side-effects, but it seems to be working fine for me.
