### PR TITLE
Quick'n'dirty port to FreeBSD (checked on FreeBSD 9.2/amd64)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -44,7 +44,7 @@ ifeq ($(OS),linux)
   OSLIBS=-lcrypto -lpthread -lrt -lcurses
 endif
 ifeq ($(OS),freebsd)
-  OSLIBS=-lcrypto -lpthread -lcurses -lkvm
+  OSLIBS=-lcrypto -lpthread -lncurses -lkvm
 endif
 
 LIBS=-lgmp -ltermcap -lsigsegv $(OSLIBS)

--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,8 @@ ifeq ($(UNAME),Darwin)
   OS=osx
 else ifeq ($(UNAME),Linux)
   OS=linux
+else ifeq ($(UNAME),FreeBSD)
+  OS=freebsd
 else 
   $(error unknown unix)
 endif
@@ -40,6 +42,9 @@ ifeq ($(OS),osx)
 endif
 ifeq ($(OS),linux)
   OSLIBS=-lcrypto -lpthread -lrt -lcurses
+endif
+ifeq ($(OS),freebsd)
+  OSLIBS=-lcrypto -lpthread -lcurses -lkvm
 endif
 
 LIBS=-lgmp -ltermcap -lsigsegv $(OSLIBS)
@@ -250,7 +255,7 @@ LIBUV=outside/libuv/libuv.a
 all: $(BIN)/vere
 
 $(LIBUV): 
-	make -C outside/libuv
+	$(MAKE) -C outside/libuv
 
 $(BIN)/vere: $(VERE_OFILES) $(LIBUV)
 	mkdir -p $(BIN)
@@ -264,5 +269,5 @@ etags:
 
 clean:
 	 $(RM) $(VERE_OFILES) $(BIN)/vere $(BIN)/eyre 
-	make -C outside/libuv clean
+	$(MAKE) -C outside/libuv clean
 

--- a/f/coal.c
+++ b/f/coal.c
@@ -126,6 +126,11 @@ u2_cf_flat_date(u2_noun pas)
 #elif defined(U2_OS_osx)
     return ( ((c3_d)pas_s.st_mtimespec.tv_sec) +
              ((c3_d)(pas_s.st_mtimespec.tv_nsec / 1000)) );
+#elif defined(U2_OS_freebsd)
+    return ( ((c3_d)pas_s.st_mtim.tv_sec) +
+             ((c3_d)(pas_s.st_mtim.tv_nsec / 1000)) );
+#else
+    #error "port: filetime"
 #endif
   }
 }

--- a/f/loom.c
+++ b/f/loom.c
@@ -284,9 +284,14 @@ u2_loom_save(c3_w ent_w)
 #if defined(U2_OS_linux)
     fdatasync(ceg_u->ctl_i);
     fdatasync(ceg_u->dat_i);
-#else
+#elif defined(U2_OS_osx)
     fcntl(ceg_u->ctl_i, F_FULLFSYNC); 
-    fcntl(ceg_u->dat_i, F_FULLFSYNC); 
+    fcntl(ceg_u->dat_i, F_FULLFSYNC);
+#elif defined(U2_OS_freebsd)
+    fsync(ceg_u->ctl_i);
+    fsync(ceg_u->dat_i);
+#else
+    #error "port: datasync" 
 #endif
   }
 

--- a/f/trac.c
+++ b/f/trac.c
@@ -138,6 +138,10 @@ _tx_samp_on(u2_ray rac_r)
     sig_s.sa_flags = 0;
 #elif defined(U2_OS_linux)
     // TODO: support profiling on linux
+#elif defined(U2_OS_freebsd)
+    // TODO: support profiling on freebsd
+#else
+   #error "port: profiling"
 #endif
     sigaction(SIGPROF, &sig_s, 0);
 

--- a/f/unix.c
+++ b/f/unix.c
@@ -312,6 +312,12 @@ u2_ux_fresh(const c3_c* paf_c,
          (nam_stat.st_mtimespec.tv_sec > nom_stat.st_mtimespec.tv_sec) ||
          ((nam_stat.st_mtimespec.tv_sec == (nam_stat.st_mtimespec.tv_sec)) &&
           (nam_stat.st_mtimespec.tv_nsec > nom_stat.st_mtimespec.tv_nsec))
+#elif defined(U2_OS_freebsd)
+         (nam_stat.st_mtim.tv_sec > nom_stat.st_mtim.tv_sec) ||
+         ((nam_stat.st_mtim.tv_sec == (nom_stat.st_mtim.tv_sec)) &&
+          (nam_stat.st_mtim.tv_nsec > nom_stat.st_mtim.tv_nsec))
+#else
+         #error "port: file time compare"
 #endif
          ) {
       return u2_no;

--- a/gen191/5/shax.c
+++ b/gen191/5/shax.c
@@ -5,10 +5,12 @@
 #include "all.h"
 #include "../pit.h"
 
-#if defined(U2_OS_linux)
+#if defined(U2_OS_linux) || defined(U2_OS_freebsd)
 #include <openssl/sha.h>
 #elif defined(U2_OS_osx)
 #include <CommonCrypto/CommonDigest.h>
+#else
+#error "port: sha256"
 #endif
 
 /* functions
@@ -23,7 +25,7 @@
     u2_bytes(0, met_w, fat_y, a);
     {
       c3_y dig_y[32];
-#if defined(U2_OS_linux)
+#if defined(U2_OS_linux) || defined(U2_OS_freebsd)
       SHA256_CTX ctx_h;
 
       SHA256_Init(&ctx_h);
@@ -35,6 +37,8 @@
       CC_SHA256_Init(&ctx_h);
       CC_SHA256_Update(&ctx_h, fat_y, met_w);
       CC_SHA256_Final(dig_y, &ctx_h);
+#else
+      #error "port: sha256"
 #endif
       return u2_rl_bytes(wir_r, 32, dig_y);
     }

--- a/include/c/portable.h
+++ b/include/c/portable.h
@@ -47,6 +47,24 @@
 #     include <sys/resource.h>
 #     include <sys/mman.h>
 
+#   elif defined(U2_OS_freebsd)
+#     include <stdlib.h>
+#     include <string.h>
+#     include <stdarg.h>
+#     include <unistd.h>
+#     include <stdint.h>
+#     include <assert.h>
+#     include <machine/endian.h>
+#     include <setjmp.h>
+#     include <stdio.h>
+#     include <signal.h>
+#     include <sys/time.h>
+#     include <sys/resource.h>
+#     include <sys/mman.h>
+
+#   else
+      #error "port: headers"
+
 #   endif
 
   /** Address space layout.
@@ -61,6 +79,15 @@
 #     define U2_OS_LoomBase 0x4000000
 #   endif
 #     define U2_OS_LoomBits 28            //  ie, 2^28 words == 1GB
+# elif defined(U2_OS_freebsd)
+#   ifdef __LP64__
+#     define U2_OS_LoomBase 0x200000000
+#   else
+#     define U2_OS_LoomBase 0x4000000
+#   endif
+#     define U2_OS_LoomBits 28            //  ie, 2^28 words == 1GB
+# else
+#   error "port: LoomBase"
 # endif
 
   /** Global variable control.
@@ -101,7 +128,7 @@
 
     /* Byte swapping.
     */
-#      if defined(U2_OS_linux)
+#      if defined(U2_OS_linux) || defined(U2_OS_freebsd)
 #        define c3_bswap_16(x)  bswap_16(x)
 #        define c3_bswap_32(x)  bswap_32(x)
 #        define c3_bswap_64(x)  bswap_64(x)
@@ -110,6 +137,8 @@
 #        define c3_bswap_16(x)  NXSwapShort(x)
 #        define c3_bswap_32(x)  NXSwapInt(x)
 #        define c3_bswap_64(x)  NXSwapLongLong(x)
+#      else
+#        error "port: byte swap"
 #      endif
 
 /* Stat struct
@@ -118,4 +147,8 @@
 #        define c3_stat_mtime(dp) (u2_time_t_in_ts((dp)->st_mtime))
 #      elif defined(U2_OS_osx)
 #        define c3_stat_mtime(dp) (u2_time_in_ts(&((dp)->st_mtimespec)))
+#      elif defined(U2_OS_freebsd)
+#        define c3_stat_mtime(dp) (u2_time_in_ts(&((dp)->st_mtim)))
+#      else
+#        error "port: timeconvert"
 #      endif

--- a/v/unix.c
+++ b/v/unix.c
@@ -127,8 +127,12 @@ u2_unix_acquire(c3_c* pax_c)
     c3_i fid_i = fileno(loq_u);
 #if defined(U2_OS_linux)
     fdatasync(fid_i);
-#else
+#elif defined(U2_OS_osx)
     fcntl(fid_i, F_FULLFSYNC); 
+#elif defined(U2_OS_freebsd)
+    fsync(fid_i);
+#else
+    #error "port: datasync"
 #endif
   }
   fclose(loq_u);


### PR DESCRIPTION
This is quick'n'dirty port of Urbit to FreeBSD 9.2/amd64. 'vere' starts at least.
Please, consider it for merge
