### PR TITLE
Fixes to hoon-mode.el that got lost in the merge

### DIFF
--- a/extras/hoon-mode.el/hoon-mode.el
+++ b/extras/hoon-mode.el/hoon-mode.el
@@ -43,7 +43,7 @@
     (modify-syntax-entry ?\' "\"" st)
     (modify-syntax-entry ?| "." st)
     (modify-syntax-entry ?; "." st)
-    (modify-syntax-entry ?\" "." st)
+    (modify-syntax-entry ?\" "\"" st)
     (modify-syntax-entry ?: ". 12b" st)
     (modify-syntax-entry ?\n "> b" st)
     st)
@@ -94,5 +94,5 @@
   0) ;;TODO
 
 
-(provide 'hoon)
+(provide 'hoon-mode)
 ;;; hoon.el ends here


### PR DESCRIPTION
1. provide 'hoon-mode instead of 'hoon
2. treat double-quote as syntactic quote (fixes "'" hosing font-lock)
