### PR TITLE
loom.c -- drop unnecessary fsync in _loom_write that causes lag on some systems.

### DIFF
--- a/f/loom.c
+++ b/f/loom.c
@@ -84,7 +84,6 @@ _loom_write(c3_i fid_i, void* buf_w, c3_w len_w)
     exit(1);
   }
   else {
-    fsync(fid_i);   //  for what it's worth
     return u2_yes;
   }
 //  return ((4 * len_w) == write(fid_i, buf_w, (4 * len_w))) ? u2_yes : u2_no;


### PR DESCRIPTION
u2_loom_save syncs after writing anyway.
