### PR TITLE
Exit 0 on successful daemonization

### DIFF
--- a/v/main.c
+++ b/v/main.c
@@ -225,7 +225,7 @@ main(c3_i   argc,
     }
     if ( pid ) {
       printf("%s: daemon: process %d\n", argv[0], pid);
-      exit(1);
+      exit(0);
     }
   }
 


### PR DESCRIPTION
Doesn't fix anything major, but it's a little more correct.
