### PR TITLE
Remove trailing paren

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ else ifeq ($(UNAME),Linux)
   OS=linux
 else ifeq ($(UNAME),FreeBSD)
   OS=bsd
-else ifeq ($(UNAME),OpenBSD))
+else ifeq ($(UNAME),OpenBSD)
   OS=bsd
 else 
   $(error unknown unix)


### PR DESCRIPTION
Didn't notice this until trying to compile on the broken build and investigating the log... apparently this doesn't actually stop OpenBSD's gmake from compiling, but does result in printing a warning.
