### PR TITLE
Remove most instances of strcpy and sprintf

### DIFF
--- a/f/coal.c
+++ b/f/coal.c
@@ -82,11 +82,13 @@ u2_cf_path(c3_c* top_c,
 {
   c3_w    top_w = strlen(top_c);
   c3_w    len_w = _cf_path_1(0, (top_w + 1), tah);
-  c3_c*   buf_c = malloc(len_w + (ext_c ? (1 + strlen(ext_c)) : 0) + 1);
+  c3_w    buf_w = len_w + (ext_c ? (1 + strlen(ext_c)) : 0);
+  c3_c*   buf_c = malloc(buf_w + 1);
   c3_w    pos_w;
   u2_noun pas;
 
-  strcpy(buf_c, top_c);
+  strncpy(buf_c, top_c, buf_w);
+  buf_c[buf_w] = '\0';
   pos_w = top_w;
   buf_c[pos_w++] = '/';
 
@@ -94,7 +96,7 @@ u2_cf_path(c3_c* top_c,
 
   if ( ext_c ) {
     buf_c[pos_w++] = '.'; 
-    strcpy(buf_c + pos_w, ext_c);
+    strncpy(buf_c + pos_w, ext_c, buf_w - pos_w);
   } else {
     buf_c[pos_w] = 0;
   }

--- a/v/ames.c
+++ b/v/ames.c
@@ -65,7 +65,7 @@ _ames_czar(c3_y imp_y, c3_s* por_s)
       c3_c*   nam_c = u2_cr_string(nam);
       c3_c    dns_c[64];
 
-      sprintf(dns_c, "%s.urbit.org", nam_c + 1);
+      snprintf(dns_c, 64, "%s.urbit.org", nam_c + 1);
       // uL(fprintf(uH, "czar %s, dns %s\n", nam_c, dns_c));
       free(nam_c);
       u2z(nam);

--- a/v/http.c
+++ b/v/http.c
@@ -219,7 +219,7 @@ _http_respond_request(u2_hreq* req_u,
 {
   c3_c buf_c[81];
 
-  sprintf(buf_c, "HTTP/1.1 %d %s\r\n",
+  snprintf(buf_c, 81, "HTTP/1.1 %d %s\r\n",
                  rep_u->sas_w,
                  (rep_u->sas_w == 200) ? "OK" : "Hosed");
   _http_respond_str(req_u, buf_c);
@@ -231,12 +231,12 @@ _http_respond_request(u2_hreq* req_u,
   //  Why is this necessary?  Why can't we send a naked error?  Waah.
   //
   if ( !rep_u->bod_u ) {
-    sprintf(buf_c, "HTTP error %d.\r\n", rep_u->sas_w);
+    snprintf(buf_c, 81, "HTTP error %d.\r\n", rep_u->sas_w);
     rep_u->bod_u = _http_bod(strlen(buf_c), (c3_y*) buf_c);
   }
 
   {
-    sprintf(buf_c, "content-length: %u\r\n", rep_u->bod_u->len_w);
+    snprintf(buf_c, 81, "content-length: %u\r\n", rep_u->bod_u->len_w);
     _http_respond_str(req_u, buf_c);
 
     _http_respond_str(req_u, "\r\n");

--- a/v/loop.c
+++ b/v/loop.c
@@ -976,13 +976,13 @@ _lo_home(u2_reck* rec_u)
   {
     mkdir(u2_Host.cpu_c, 0700);
 
-    sprintf(ful_c, "%s/get", u2_Host.cpu_c);
+    snprintf(ful_c, 2048, "%s/get", u2_Host.cpu_c);
     if ( 0 != mkdir(ful_c, 0700) ) {
       perror(ful_c);
       u2_lo_bail(rec_u);
     }
 
-    sprintf(ful_c, "%s/put", u2_Host.cpu_c);
+    snprintf(ful_c, 2048, "%s/put", u2_Host.cpu_c);
     if ( 0 != mkdir(ful_c, 0700) ) {
       perror(ful_c);
       u2_lo_bail(rec_u);
@@ -992,7 +992,7 @@ _lo_home(u2_reck* rec_u)
   //  Copy urbit.pill.
   //
   {
-    sprintf(ful_c, "cp %s/urbit.pill %s", 
+    snprintf(ful_c, 2048, "cp %s/urbit.pill %s", 
                     u2_Host.ops_u.hom_c, u2_Host.cpu_c);
     if ( 0 != system(ful_c) ) {
       uL(fprintf(uH, "could not %s\n", ful_c));
@@ -1142,10 +1142,10 @@ _lo_fast(u2_reck* rec_u, u2_noun pas, c3_l key_l)
   {
     c3_i fid_i;
 
-    sprintf(ful_c, "%s/.urbit", hom_c);
+    snprintf(ful_c, 2048, "%s/.urbit", hom_c);
     mkdir(ful_c, 0700);
 
-    sprintf(ful_c, "%s/.urbit/%s.txt", hom_c, gum_c);
+    snprintf(ful_c, 2048, "%s/.urbit/%s.txt", hom_c, gum_c);
     if ( (fid_i = open(ful_c, O_CREAT | O_TRUNC | O_WRONLY, 0600)) < 0 ) {
       uL(fprintf(uH, "fast: could not save %s\n", ful_c));
       u2_lo_bail(rec_u);
@@ -1171,7 +1171,7 @@ _lo_staf(u2_reck* rec_u, c3_l key_l)
   c3_c*   gum_c = u2_cr_string(gum);
   u2_noun txt;
 
-  sprintf(ful_c, "%s/.urbit/%s.txt", hom_c, gum_c);
+  snprintf(ful_c, 2048, "%s/.urbit/%s.txt", hom_c, gum_c);
   txt = u2_walk_safe(ful_c);
 
   if ( 0 == txt ) {
@@ -1232,7 +1232,7 @@ _lo_zest(u2_reck* rec_u)
   
   //  Create the record file.
   {
-    sprintf(ful_c, "%s/egz.hope", u2_Host.cpu_c);
+    snprintf(ful_c, 2048, "%s/egz.hope", u2_Host.cpu_c);
 
     if ( ((fid_i = open(ful_c, O_CREAT | O_WRONLY | O_EXCL, 0600)) < 0) || 
          (fstat(fid_i, &buf_b) < 0) ) 
@@ -1309,7 +1309,7 @@ _lo_zest(u2_reck* rec_u)
 #if 0
   //  Copy the egz into ham, the factory default.
   {
-    sprintf(ful_c, "rm -f %s/~ham.hope; cp %s/~egz.hope %s/~ham.hope",
+    snprintf(ful_c, 8193, "rm -f %s/~ham.hope; cp %s/~egz.hope %s/~ham.hope",
                    u2_Host.cpu_c, u2_Host.cpu_c, u2_Host.cpu_c);
 
     if ( 0 != system(ful_c) ) {
@@ -1367,7 +1367,7 @@ _lo_rest(u2_reck* rec_u)
 
   //  Open the fscking file.  Does it even exist?
   {
-    sprintf(ful_c, "%s/egz.hope", u2_Host.cpu_c);
+    snprintf(ful_c, 2048, "%s/egz.hope", u2_Host.cpu_c);
 
     if ( ((fid_i = open(ful_c, O_RDWR)) < 0) || 
          (fstat(fid_i, &buf_b) < 0) ) 

--- a/v/main.c
+++ b/v/main.c
@@ -101,13 +101,14 @@ _main_getopt(c3_i argc, c3_c** argv)
 
     if ( u2_Host.ops_u.hom_c == 0 ) {
       c3_c* hom_c = getenv("HOME");
+      c3_w hom_w = strlen(hom_c + 6);
 
       if ( !hom_c ) {
         fprintf(stderr, "$URBIT_HOME or $HOME must be set\n");
         exit(1);
       } else {
-        u2_Host.ops_u.hom_c = malloc(strlen(hom_c) + 7);
-        sprintf(u2_Host.ops_u.hom_c, "%s/urbit", hom_c);
+        u2_Host.ops_u.hom_c = malloc(hom_w + 1);
+        snprintf(u2_Host.ops_u.hom_c, hom_w + 1, "%s/urbit", hom_c);
       }
     }
     {

--- a/v/reck.c
+++ b/v/reck.c
@@ -158,7 +158,7 @@ _reck_load_arvo(u2_reck* rec_u, c3_c* pax_c)
 {
   c3_c ful_c[2048];
 
-  sprintf(ful_c, "%s/%d/arvo/%s.hoon", u2_System, rec_u->kno_w, pax_c);
+  snprintf(ful_c, 2048, "%s/%d/arvo/%s.hoon", u2_System, rec_u->kno_w, pax_c);
 
   return u2_walk_load(ful_c);
 }
@@ -293,9 +293,9 @@ u2_reck_cold(u2_reck* rec_u, c3_w kno_w)
     c3_c    ful_c[2048];
 
     if ( u2_yes == u2_Host.ops_u.nuu ) {
-      sprintf(ful_c, "%s/urbit.pill", u2_Host.ops_u.hom_c);
+      snprintf(ful_c, 2048, "%s/urbit.pill", u2_Host.ops_u.hom_c);
     } else {
-      sprintf(ful_c, "%s/urbit.pill", u2_Host.ops_u.cpu_c);
+      snprintf(ful_c, 2048, "%s/urbit.pill", u2_Host.ops_u.cpu_c);
     }
     printf("loading %s\n", ful_c);
 

--- a/v/term.c
+++ b/v/term.c
@@ -524,7 +524,8 @@ _term_it_path(u2_bean fyl, u2_noun pax)
   //  cut
   //
   pas_c = malloc(len_w + 1);
-  strcpy(pas_c, u2_Host.cpu_c);
+  strncpy(pas_c, u2_Host.cpu_c, len_w);
+  pas_c[len_w] = '\0';
   {
     u2_noun wiz   = pax;
     c3_c*   waq_c = (pas_c + strlen(pas_c));

--- a/v/unix.c
+++ b/v/unix.c
@@ -28,11 +28,13 @@ static c3_c*
 _unix_down(c3_c* pax_c, c3_c* sub_c)
 {
   c3_w pax_w = strlen(pax_c);
+  c3_w sub_w = strlen(sub_c);
   c3_c* don_c = malloc(pax_w + strlen(sub_c) + 2);
 
-  strcpy(don_c, pax_c);
+  strncpy(don_c, pax_c, pax_w + 1);
   don_c[pax_w] = '/';
-  strcpy(don_c + pax_w + 1, sub_c);
+  strncpy(don_c + pax_w + 1, sub_c, sub_w + 1);
+  don_c[pax_w + sub_w + 1] = '\0';
 
   return don_c;
 }
@@ -230,14 +232,15 @@ _unix_file_form(u2_udir* dir_u,
   c3_w  ket_w = (u2_yes == ket) ? 1 : 0;
   c3_c* pax_c = malloc(pax_w + 1 + pre_w + 1 + ket_w + ext_w + 1);
 
-  strcpy(pax_c, dir_u->pax_c);
+  strncpy(pax_c, dir_u->pax_c, pax_w);
   pax_c[pax_w] = '/';
-  strcpy(pax_c + pax_w + 1, pre_c);
+  strncpy(pax_c + pax_w + 1, pre_c, pre_w);
   pax_c[pax_w + 1 + pre_w] = '.';
   if ( u2_yes == ket ) {
     pax_c[pax_w + 1 + pre_w + 1] = '^';
   }
-  strcpy(pax_c + pax_w + 1 + pre_w + 1 + ket_w, ext_c);
+  strncpy(pax_c + pax_w + 1 + pre_w + 1 + ket_w, ext_c, ext_w);
+  pax_c[pax_w + 1 + pre_w + 1 + ket_w + ext_w] = '\0';
 
   free(pre_c); free(ext_c);
   u2z(pre); u2z(ext);
@@ -274,9 +277,10 @@ _unix_dir_forge(u2_udir* dir_u, u2_udir* par_u, u2_noun tet)
     c3_w  tet_w = strlen(tet_c);
     c3_c* pax_c = malloc(pax_w + 1 + tet_w + 1);
 
-    strcpy(pax_c, par_u->pax_c);
+    strncpy(pax_c, par_u->pax_c, pax_w + 1);
     pax_c[pax_w] = '/';
-    strcpy(pax_c + pax_w + 1, tet_c);
+    strncpy(pax_c + pax_w + 1, tet_c, tet_w + 1);
+    pax_c[pax_w + tet_w + 1] = '\0';
 
     free(tet_c);
     u2z(tet);

--- a/v/walk.c
+++ b/v/walk.c
@@ -181,9 +181,10 @@ _walk_in(u2_reck* rec_u, const c3_c* dir_c, c3_w len_w)
       c3_c*  pat_c = malloc(lef_w + 1);
       struct stat buf_b;
   
-      strcpy(pat_c, dir_c);
+      strncpy(pat_c, dir_c, lef_w);
       pat_c[len_w] = '/';
-      strcpy(pat_c + len_w + 1, fil_c);
+      strncpy(pat_c + len_w + 1, fil_c, lef_w);
+      pat_c[lef_w] = '\0';
 
       if ( 0 != stat(pat_c, &buf_b) ) {
         free(pat_c);
@@ -277,7 +278,8 @@ u2_path(u2_bean fyl, u2_noun pax)
   //  cut
   //
   pas_c = malloc(len_w + 1);
-  strcpy(pas_c, u2_Local);
+  strncpy(pas_c, u2_Local, len_w);
+  pas_c[len_w] = '\0';
   {
     u2_noun wiz   = pax;
     c3_c*   waq_c = (pas_c + strlen(pas_c));


### PR DESCRIPTION
OpenBSD whines about these and recommends using strlcpy / snprintf
instead. Since strlcpy isn't quite universal yet, we use strncpy instead
and be careful about terminating the string. We could implement a
portable strlcpy in terms of strncpy, but that'd add another function to
the namespace.

Yes, usually the length is obviously bounded. Still, pretending
strcpy/sprintf don't exist seems like a great strategy.

N.B. there are still a few occurrences of strcpy and sprintf under f/
and in libuv, but I don't have time to tackle them right now.
