### PR TITLE
Formatting issue on line 2955

### DIFF
--- a/urb/zod/arvo/hoon.hoon
+++ b/urb/zod/arvo/hoon.hoon
@@ -2952,7 +2952,8 @@
     ==
   ++  nuck
     %+  knee  *coin  |.  ~+
-    %-  stew  :~
+    %-  stew
+    :~
       :-  ['a' 'z']  (cook |=(a=@ta [~ %tas a]) sym)
       :-  ['0' '9']  (stag ~ bisk) 
       :-  '-'        (stag ~ tash)


### PR DESCRIPTION
The tall form of the :~ is improperly indented. The subhoons should be two spaces to the right of the colsig, and then the == terminator should be directly below the initiating colsig. Instead, the subhoons are improperly indented such that that they confusingly appear to be subhoons of the previous rune (cenhep).

Fixing by moving the colsig to the next line.

Maybe my Git-Fu is low. I'm not seeing this request in email, perhaps I need to bring it up to my fork first?
