### PR TITLE
Remove remainder of sprintf & strcpy calls

### DIFF
--- a/f/trac.c
+++ b/f/trac.c
@@ -82,7 +82,7 @@
         if ( 0 == (dis_k = _tx_knot_new()) ) {
           return 0;
         } else {
-          strcpy(dis_k->lic_c, hed_c);
+          strncpy(dis_k->lic_c, hed_c, 31);
           dis_k->fin_w = 1;
           dis_k->fam_k = 0;
           dis_k->nex_k = par_k->fam_k;

--- a/f/unix.c
+++ b/f/unix.c
@@ -148,8 +148,8 @@ u2_ux_read(u2_ray      wir_r,
   
   nam_c = alloca(len_w + 1);
   if ( ext_c ) {
-    sprintf(nam_c, "%s.%s", paf_c, ext_c);
-  } else sprintf(nam_c, "%s", paf_c);
+    snprintf(nam_c, len_w + 1, "%s.%s", paf_c, ext_c);
+  } else snprintf(nam_c, len_w + 1, "%s", paf_c);
 
   {
     c3_i        fid_i;
@@ -194,8 +194,8 @@ u2_ux_read_deep(u2_wire     wir_r,
   
   nam_c = alloca(len_w + 1);
   if ( ext_c ) {
-    sprintf(nam_c, "%s.%s", paf_c, ext_c);
-  } else sprintf(nam_c, "%s", paf_c);
+    snprintf(nam_c, len_w + 1, "%s.%s", paf_c, ext_c);
+  } else snprintf(nam_c, len_w + 1, "%s", paf_c);
 
   {
     FILE*   fil;
@@ -227,8 +227,8 @@ u2_ux_write(u2_wire     wir_r,
   
   nam_c = alloca(len_w + 1);
   if ( ext_c ) {
-    sprintf(nam_c, "%s.%s", paf_c, ext_c);
-  } else sprintf(nam_c, "%s", paf_c);
+    snprintf(nam_c, len_w + 1, "%s.%s", paf_c, ext_c);
+  } else snprintf(nam_c, len_w + 1, "%s", paf_c);
 
   {
     c3_i    fid_i;
@@ -269,8 +269,8 @@ u2_ux_write_deep(u2_wire     wir_r,
   
   nam_c = alloca(len_w + 1);
   if ( ext_c ) {
-    sprintf(nam_c, "%s.%s", paf_c, ext_c);
-  } else sprintf(nam_c, "%s", paf_c);
+    snprintf(nam_c, len_w + 1, "%s.%s", paf_c, ext_c);
+  } else snprintf(nam_c, len_w + 1, "%s", paf_c);
 
   {
     FILE*   fil;
@@ -298,8 +298,8 @@ u2_ux_fresh(const c3_c* paf_c,
   c3_c* nom_c = alloca(nom_w + 1);
   struct stat nam_stat, nom_stat;
 
-  sprintf(nam_c, "%s.%s", paf_c, ext_c);
-  sprintf(nom_c, "%s.%s", paf_c, oxt_c);
+  snprintf(nam_c, nam_w + 1, "%s.%s", paf_c, ext_c);
+  snprintf(nom_c, nom_w + 1, "%s.%s", paf_c, oxt_c);
 
   if ( stat(nam_c, &nam_stat) < 0 ) {
     return u2_no;

--- a/f/wire.c
+++ b/f/wire.c
@@ -110,13 +110,13 @@ _wr_open(c3_c* cpu_c, c3_c* fil_c, c3_c* suf_c)
   c3_c ful_c[8193];
   c3_i fid_i;
 
-  sprintf(ful_c, "%s", cpu_c);
+  snprintf(ful_c, 8193, "%s", cpu_c);
   mkdir(ful_c, 0700);
 
-  sprintf(ful_c, "%s/chk", cpu_c);
+  snprintf(ful_c, 8193, "%s/chk", cpu_c);
   mkdir(ful_c, 0700);
 
-  sprintf(ful_c, "%s/chk/%s.%s", cpu_c, fil_c, suf_c);
+  snprintf(ful_c, 8193, "%s/chk/%s.%s", cpu_c, fil_c, suf_c);
   fid_i = open(ful_c, O_RDWR | O_CREAT, 0666);
   if ( -1 == fid_i ) {
     perror(ful_c); exit(1);

--- a/v/term.c
+++ b/v/term.c
@@ -392,7 +392,7 @@ _term_it_write_strnum(u2_utty* uty_u, const c3_c* str_c, c3_w num_w)
 {
   c3_c buf_c[16];
 
-  sprintf(buf_c, "#%ud", num_w);   //  XX slow
+  snprintf(buf_c, 16, "#%ud", num_w);   //  XX slow
   _term_it_write_str(uty_u, str_c);
   _term_it_write_str(uty_u, buf_c);
 }


### PR DESCRIPTION
Note that there are still some in libuv.
