### PR TITLE
Get it builing on OpenBSD 5.3

### DIFF
--- a/outside/libuv/include/uv-private/uv-unix.h
+++ b/outside/libuv/include/uv-private/uv-unix.h
@@ -133,7 +133,7 @@ typedef UV_PLATFORM_SEM_T uv_sem_t;
 typedef pthread_cond_t uv_cond_t;
 
 
-#if defined(__OpenBSD__) || (defined(__APPLE__) && defined(__MACH__))
+#if defined(__APPLE__) && defined(__MACH__)
 
 typedef struct {
   unsigned int n;
@@ -143,11 +143,11 @@ typedef struct {
   uv_sem_t turnstile2;
 } uv_barrier_t;
 
-#else /* defined(__OpenBSD__) || (defined(__APPLE__) && defined(__MACH__)) */
+#else /* defined(__APPLE__) && defined(__MACH__) */
 
 typedef pthread_barrier_t uv_barrier_t;
 
-#endif /* defined(__OpenBSD__) || (defined(__APPLE__) && defined(__MACH__)) */
+#endif /* defined(__APPLE__) && defined(__MACH__) */
 
 /* Platform-specific definitions for uv_spawn support. */
 typedef gid_t uv_gid_t;

--- a/outside/libuv/src/unix/openbsd.c
+++ b/outside/libuv/src/unix/openbsd.c
@@ -175,7 +175,7 @@ uv_err_t uv_get_process_title(char* buffer, size_t size) {
 
 uv_err_t uv_resident_set_memory(size_t* rss) {
   kvm_t *kd = NULL;
-  struct kinfo_proc2 *kinfo = NULL;
+  struct kinfo_proc *kinfo = NULL;
   pid_t pid;
   int nprocs, max_size = sizeof(struct kinfo_proc);
   size_t page_size = getpagesize();
@@ -185,7 +185,7 @@ uv_err_t uv_resident_set_memory(size_t* rss) {
   kd = kvm_open(NULL, _PATH_MEM, NULL, O_RDONLY, "kvm_open");
   if (kd == NULL) goto error;
 
-  kinfo = kvm_getproc2(kd, KERN_PROC_PID, pid, max_size, &nprocs);
+  kinfo = kvm_getprocs(kd, KERN_PROC_PID, pid, max_size, &nprocs);
   if (kinfo == NULL) goto error;
 
   *rss = kinfo->p_vm_rssize * page_size;

--- a/outside/libuv/src/unix/thread.c
+++ b/outside/libuv/src/unix/thread.c
@@ -266,7 +266,7 @@ int uv_sem_trywait(uv_sem_t* sem) {
 #endif /* defined(__APPLE__) && defined(__MACH__) */
 
 
-#if defined(__OpenBSD__) || (defined(__APPLE__) && defined(__MACH__))
+#if defined(__APPLE__) && defined(__MACH__)
 
 int uv_cond_init(uv_cond_t* cond) {
   if (pthread_cond_init(cond, NULL))
@@ -275,7 +275,7 @@ int uv_cond_init(uv_cond_t* cond) {
     return 0;
 }
 
-#else /* !(defined(__OpenBSD__) || (defined(__APPLE__) && defined(__MACH__))) */
+#else /* !(defined(__APPLE__) && defined(__MACH__)) */
 
 int uv_cond_init(uv_cond_t* cond) {
   pthread_condattr_t attr;
@@ -301,7 +301,7 @@ error2:
   return -1;
 }
 
-#endif /* defined(__OpenBSD__) || (defined(__APPLE__) && defined(__MACH__)) */
+#endif /* defined(__APPLE__) && defined(__MACH__) */
 
 void uv_cond_destroy(uv_cond_t* cond) {
   if (pthread_cond_destroy(cond))
@@ -351,7 +351,7 @@ int uv_cond_timedwait(uv_cond_t* cond, uv_mutex_t* mutex, uint64_t timeout) {
 }
 
 
-#if defined(__OpenBSD__) || (defined(__APPLE__) && defined(__MACH__))
+#if defined(__APPLE__) && defined(__MACH__)
 
 int uv_barrier_init(uv_barrier_t* barrier, unsigned int count) {
   barrier->n = count;
@@ -406,7 +406,7 @@ void uv_barrier_wait(uv_barrier_t* barrier) {
   uv_sem_post(&barrier->turnstile2);
 }
 
-#else /* !(defined(__OpenBSD__) || (defined(__APPLE__) && defined(__MACH__))) */
+#else /* !(defined(__APPLE__) && defined(__MACH__)) */
 
 int uv_barrier_init(uv_barrier_t* barrier, unsigned int count) {
   if (pthread_barrier_init(barrier, NULL, count))
@@ -428,4 +428,4 @@ void uv_barrier_wait(uv_barrier_t* barrier) {
     abort();
 }
 
-#endif /* defined(__OpenBSD__) || (defined(__APPLE__) && defined(__MACH__)) */
+#endif /* defined(__APPLE__) && defined(__MACH__) */


### PR DESCRIPTION
Turns out 4.8 and 5.3 offer mutually incompatible kvm_getprocs
interfaces. kvm_getproc2 was removed at some point, and kvm_getprocs
changed to have the API that kvm_getproc2 used to have.

I've decided to sac 4.8 support. devio.us still runs 4.8, but their
ulimit is set too low for vere anyway.

This reverts commit b9a83028891652e2e994f7c0a1cbb992c647f145.
