### PR TITLE
Support ^R (reverse incremental search) in dill.

### DIFF
--- a/urb/zod/arvo/dill.hoon
+++ b/urb/zod/arvo/dill.hoon
@@ -36,6 +36,14 @@
     ^+  +>
     =.  q.q.yar  [~ bed]
     %-  curb
+    |-
+    ?^  hyr.u.q.q.yar
+      =+  ris="(reverse-i-search)'{(tufa u.hyr.u.q.q.yar)}': "
+      %=  $
+        pot.bed  ris
+        pol.bed  (lent ris)
+        hyr.u.q.q.yar  ~
+      ==
     :~  [%hop (add pol.bed bus.bed)]
         :-  %lin
         %+  weld  pot.bed
@@ -98,6 +106,40 @@
       r.r.q.yar  [txt r.r.q.yar]
     ==
   :: 
+  ++  look                                              :: search in history
+    |=  [hup=@ud txt=(list ,@c)]
+    ^+  +>
+    =+  ^=  beg
+        |=  [p=(list ,@c) x=(list ,@c)]  ::  XX how to make this generic?
+        |-
+        ?~  p
+          %.y
+        ?~  x
+          %.n
+        ?.  =(i.p i.x)
+          %.n
+        $(p t.p, x t.x)
+    =+  ^=  mid
+        |=  [i=(list ,@c) x=(list ,@c)]
+        |-
+        ?~  i
+          %.y
+        ?~  x
+          %.n
+        ?:  (beg i x)
+          %.y
+        $(x t.x)
+    ?:  =(hup p.hyt.u.q.q.yar)
+      beep
+    =+  ^=  but  ^-  (list ,@c)  ::  XX copy-paste from gore
+        =+  byt=(~(get by hym.u.q.q.yar) hup)
+        ?^  byt  u.byt
+        (tuba (rip 3 (snag hup q.hyt.u.q.q.yar)))
+    ?:  (mid txt but)
+      =.  hyr.u.q.q.yar  [~ txt]
+      (gore hup)
+    $(hup +(hup))
+  :: 
   ++  leap                                              ::  terminal event
     |-  ^+  +
     ?+    -.fav
@@ -107,6 +149,25 @@
         %belt                                           ::  terminal input
       ?~  q.q.yar
         beep
+      ?^  hyr.u.q.q.yar                                 ::  handle search
+        ?+    p.fav  $(hiz.u.q.q.yar 0, hyr.u.q.q.yar ~)
+            [%bac *]
+          ?~  u.hyr.u.q.q.yar
+            (curb `(list blit)`[[%bel ~] ~])
+          %-  edit
+          %=  u.q.q.yar
+            hyr  :-  ~
+                 (scag (dec (lent u.hyr.u.q.q.yar)) `(list ,@c)`u.hyr.u.q.q.yar)
+          ==
+            [%txt *]
+          (look hiz.u.q.q.yar (weld u.hyr.u.q.q.yar p.p.fav))
+            [%ctl %g]
+          (edit u.q.q.yar(bul 0, bus 0, but ~, hiz 0, hyr ~))
+            [%ctl %r]
+          ?:  =(p.hyt.u.q.q.yar hiz.u.q.q.yar)
+            beep
+          (look +(hiz.u.q.q.yar) u.hyr.u.q.q.yar)
+        ==
       ?-    -.p.fav
           %aro                                          ::  arrow
         ?-    p.p.fav
@@ -180,6 +241,7 @@
                 bul  (sub bul.u.q.q.yar bus.u.q.q.yar)
                 but  (slag bus.u.q.q.yar but.u.q.q.yar)
               ==
+          %r  (edit u.q.q.yar(hyr [~ ~]))
           %v  +.$(mos :_(mos [wru [/b /d hen] [%kill ~]]))
           %w  +.$(mos :_(mos [wru [/b /d hen] [%limn ~]]))
           %x  +.$(mos :_(mos [wru [/b /d hen] [%ling ~]]))
@@ -332,8 +394,8 @@
 ++  load
   |=  new=vase
   ^-  vane
-  ?.  (~(nest ut -:!>(dug)) & p.new)
-    (come new)
+  :: ?.  (~(nest ut -:!>(dug)) & p.new)  ::  XX using old state unconditionally!
+  ::   (come new)
   %_  ..^$
     dug  ((map duct yard) q.new)
   ==

--- a/urb/zod/arvo/zuse.hoon
+++ b/urb/zod/arvo/zuse.hoon
@@ -1378,6 +1378,7 @@
                   hux=path                              ::  history path
                   hym=(map ,@ud (list ,@c))             ::  history overlay
                   hyt=hist                              ::  history object
+                  hyr=(unit (list ,@c))                 ::  history search
               ==                                        ::
               $:  pol=@ud                               ::  length of prompt
                   pot=tape                              ::  prompt text


### PR DESCRIPTION
^G to cancel. Canceling should probably remember your previous
history position, but doesn't.

This adds a field to ++bead, so in the absence of proper migration
support, I've simply disabled dill's nest check in ++load. It works
in this case, presumably because dill's only bead is null during
:reboot.
