### PR TITLE
Get it building on Arch Linux

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -49,7 +49,7 @@ ifeq ($(OS),bsd)
   OSLIBS=-lcrypto -lpthread -lncurses -lkvm
 endif
 
-LIBS=-lgmp -ltermcap -lsigsegv $(OSLIBS)
+LIBS=-lgmp -lncurses -lsigsegv $(OSLIBS)
 
 INCLUDE=include
 GENERATED=generated


### PR DESCRIPTION
Arch doesn't know where -ltermcap is, but -lncurses seems to work.
