### PR TITLE
Use of indent-relative until a better option is avaliable; disable tabs

### DIFF
--- a/extras/hoon-mode.el/hoon-mode.el
+++ b/extras/hoon-mode.el/hoon-mode.el
@@ -71,7 +71,8 @@
   (set (make-local-variable 'comment-use-syntax) nil)
   (set (make-local-variable 'comment-start-skip) "\\(::+\\)\\s *")
   (set (make-local-variable 'font-lock-defaults) '(hoon-font-lock-keywords))
-  (set (make-local-variable 'indent-line-function) 'hoon-indent-line)
+  (set (make-local-variable 'indent-tabs-mode nil)) ;; tabs zutiefst verboten
+  (set (make-local-variable 'indent-line-function) 'indent-relative)
   (set (make-local-variable 'imenu-generic-expression)
        hoon-imenu-generic-expression)
   (set (make-local-variable 'outline-regexp) hoon-outline-regexp)


### PR DESCRIPTION
indent-relative will at least follow the last indentation the user has set.  This is better than nothing and actually may be the best that can be done, given the artistic nature of indentation in hoon.

Also, the existing mode leaves the emacs configured to use tabs as indentation.  Might as well disable that by default in hoon mode.
