### PR TITLE
ragel is a build dep now

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -2,7 +2,7 @@ Source: urbit
 Section: unknown
 Priority: extra
 Maintainer: Urbit <urbit@urbit.org>
-Build-Depends: debhelper (>= 8.0.0), libssl-dev, libncurses5-dev, libgmp-dev, libsigsegv-dev
+Build-Depends: debhelper (>= 8.0.0), libssl-dev, libncurses5-dev, libgmp-dev, libsigsegv-dev, ragel
 Standards-Version: 3.9.3
 Homepage: http://urbit.org/
 


### PR DESCRIPTION
```
make distclean && cd .. && tar czvf urbit_0.2.orig.tar.gz --exclude .git urbit/ && \
  cd urbit && dpkg-buildpackage
```

^ this should probably also be documented somewhere, I had to be told anyway... thanks!
