### PR TITLE
I386/any architecture support

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -2,7 +2,7 @@ Source: urbit
 Section: unknown
 Priority: extra
 Maintainer: Urbit <urbit@urbit.org>
-Build-Depends: debhelper (>= 8.0.0), libssl-dev, libncurses5-dev, libgmp-dev, libsigsegv-dev
+Build-Depends: debhelper (>= 8.0.0), libssl-dev, libncurses5-dev, libgmp-dev, libsigsegv-dev, ragel
 Standards-Version: 3.9.3
 Homepage: http://urbit.org/
 

--- a/debian/control
+++ b/debian/control
@@ -7,7 +7,7 @@ Standards-Version: 3.9.3
 Homepage: http://urbit.org/
 
 Package: urbit
-Architecture: amd64
+Architecture: i386
 Depends: ${shlibs:Depends}, ${misc:Depends}
 Description: Urbit
  The Urbit virtual machine and supporting files.

--- a/debian/control
+++ b/debian/control
@@ -7,7 +7,7 @@ Standards-Version: 3.9.3
 Homepage: http://urbit.org/
 
 Package: urbit
-Architecture: i386
+Architecture: any
 Depends: ${shlibs:Depends}, ${misc:Depends}
 Description: Urbit
  The Urbit virtual machine and supporting files.

--- a/debian/files
+++ b/debian/files
@@ -1,1 +1,1 @@
-urbit_0.2-1_amd64.deb unknown extra
+urbit_0.2-1_i386.deb unknown extra

--- a/debian/files
+++ b/debian/files
@@ -1,1 +1,0 @@
-urbit_0.2-1_i386.deb unknown extra


### PR DESCRIPTION
I found out about this on freenode, I could only find "all" in the manuals... that's the wrong thing.

`Architecture: any`
